### PR TITLE
add prereleases to plugin repositories

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        maven { setUrl("https://maven.vaadin.com/vaadin-prereleases") }
     }
     plugins {
         id 'io.quarkus' version "${quarkusVersion}"


### PR DESCRIPTION
This align `pluginManagement` section in `settings.gradle` with `repositories` in `build.gradle`
Related to https://github.com/vaadin/base-starter-flow-quarkus/issues/12

