### PR TITLE
chore: Update to latest platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
-        <vaadin.version>22.0.2</vaadin.version>
+        <vaadin.version>22.0.6</vaadin.version>
 
         <quarkus.version>2.5.4.Final</quarkus.version>
     </properties>
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-quarkus</artifactId>
-            <version>1.0.0.alpha1</version> <!-- TODO: should come from vaadin-bom -->
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Remove version for vaadin-quarkus that is coming from bom
https://repo.maven.apache.org/maven2/com/vaadin/vaadin-spring-bom/22.0.6/vaadin-spring-bom-22.0.6.pom
